### PR TITLE
Add initial support for folder downloads

### DIFF
--- a/gdown/__init__.py
+++ b/gdown/__init__.py
@@ -2,6 +2,7 @@
 
 import pkg_resources
 
+from .download_folder import download_folder
 from .cached_download import cached_download
 from .cached_download import md5sum
 from .download import download

--- a/gdown/cli.py
+++ b/gdown/cli.py
@@ -8,6 +8,7 @@ import pkg_resources
 import six
 
 from .download import download
+from .download_folder import download_folder
 
 distribution = pkg_resources.get_distribution("gdown")
 
@@ -57,7 +58,7 @@ def main():
         help="display version",
     )
     parser.add_argument(
-        "url_or_id", help="url or file id (with --id) to download file from"
+        "url_or_id", help="url or file/folder id (with --id) to download file/folder from"
     )
     parser.add_argument("-O", "--output", help="output filename")
     parser.add_argument(
@@ -66,7 +67,7 @@ def main():
     parser.add_argument(
         "--id",
         action="store_true",
-        help="flag to specify file id instead of url",
+        help="flag to specify file/folder id instead of url",
     )
     parser.add_argument(
         "--proxy",
@@ -82,6 +83,11 @@ def main():
         action="store_true",
         help="don't use cookies in ~/.cache/gdown/cookies.json",
     )
+    parser.add_argument(
+        "--folder",
+        action="store_true",
+        help="download entire folder instead of a single file.",
+    )
 
     args = parser.parse_args()
 
@@ -91,20 +97,29 @@ def main():
         else:
             args.output = sys.stdout
 
-    if args.id:
+    if args.id and not args.folder:
         url = "https://drive.google.com/uc?id={id}".format(id=args.url_or_id)
+    elif args.id and args.folder:
+        url = "https://drive.google.com/folders/{id}".format(id=args.url_or_id)
     else:
         url = args.url_or_id
-
-    download(
-        url=url,
-        output=args.output,
-        quiet=args.quiet,
-        proxy=args.proxy,
-        speed=args.speed,
-        use_cookies=not args.no_cookies,
-    )
-
+    
+    if args.folder:
+        download_folder(
+            url=url,
+            quiet=args.quiet,
+            proxy=args.proxy,
+            speed=args.speed,
+        )
+    else:
+        download(
+            url=url,
+            output=args.output,
+            quiet=args.quiet,
+            proxy=args.proxy,
+            speed=args.speed,
+            use_cookies=not args.no_cookies,
+        )
 
 if __name__ == "__main__":
     main()

--- a/gdown/download_folder.py
+++ b/gdown/download_folder.py
@@ -1,0 +1,56 @@
+from bs4 import BeautifulSoup
+from .download import download
+import requests, ast
+
+client = requests.session()
+
+def download_folder(folder, quiet = False, proxy = None, speed = None):
+    """
+    Download entire folder from URL.
+
+    Parameters
+    ----------
+
+    url: str
+        URL of the Google Drive folder. Must be of the format 'https://drive.google.com/drive/folders/{url}'
+    quiet: bool, optional
+        Suppress terminal output.
+    proxy: str, optional
+        Proxy.
+    speed: float, optional
+        Download byte size per second (e.g., 256KB/s = 256 * 1024).
+
+    Returns
+    -------
+
+    output: str
+        Output filename.
+
+    Example
+    -------
+
+    gdown.download_folder("https://drive.google.com/drive/folders/1ZXEhzbLRLU1giKKRJkjm8N04cO_JoYE2")
+
+    """
+
+    folder_soup = BeautifulSoup(client.get(folder).text, features = "html.parser")
+
+    # finds the script tag with window['_DRIVE_ivd'] in it and extracts the encoded array
+    byte_string = folder_soup.find_all('script')[-3].contents[0][24:-113] 
+
+    # decodes the array and evaluates it as a python array
+    folder_arr = ast.literal_eval(byte_string.replace('\\/', "/").encode('utf-8').decode('unicode-escape').replace("\n", "").replace('null', '"null"'))
+
+    folder_file_list = [i[0] for i in folder_arr[0]]
+    folder_name_list = [i[2] for i in folder_arr[0]]
+    folder_type_list = [i[3] for i in folder_arr[0]]
+
+    for file in range(len(folder_file_list)):
+        if folder_type_list[file] != "application/vnd.google-apps.folder":
+            download("https://drive.google.com/uc?id=" + folder_file_list[file], folder_name_list[file], quiet = True, proxy = proxy, speed = speed)
+            if quiet == False:
+                print("https://drive.google.com/uc?id=" + folder_file_list[file], folder_name_list[file])
+        else:
+            if quiet == False:
+                print("Processing folder", folder_name_list[file], "(https://drive.google.com/drive/folders/" + folder_file_list[file] + ")")
+            download_folder("https://drive.google.com/drive/folders/" + folder_file_list[file], quiet = quiet, proxy = proxy, speed = speed)


### PR DESCRIPTION
This commit solves the problem of downloading entire Google Drive folders, which has been an issue for quite a while (https://github.com/wkentaro/gdown/issues/62).

This solution uses Beautiful Soup to get the `<script>` tag that contains `window['_DRIVE_ivd']`, an array that stores the folder configuration of the files and subfolders within a Google Drive folder.

It (currently) does not support cached downloads, cookie reuse, folder structure, folders and files with the same name, ~and the CLI~ **(Update: It now does)**. These may be added in a future update.